### PR TITLE
[Firebase][Backend] Link user page to Firestore

### DIFF
--- a/crumbs/crumbs/AboutViewController.swift
+++ b/crumbs/crumbs/AboutViewController.swift
@@ -16,9 +16,10 @@ class AboutViewController: UIViewController {
         super.viewDidLoad()
 
         karma.text = String(user.karma)
-        age.text = String(user.age)
+        // TODO: Calculate and display age
+        age.text = "1d"
         views.text = String(user.views)
-        crumbsCreated.text = String(user.postsCreated)
+        crumbsCreated.text = String(user.posts.count)
     }
     
 

--- a/crumbs/crumbs/Fixtures.swift
+++ b/crumbs/crumbs/Fixtures.swift
@@ -36,7 +36,6 @@ func randomString(length: Int) -> String {
 
 func generateUsersWithPosts(userBound: Int = COUNT_BOUND, postsBound: Int = COUNT_BOUND, countBound: Int = COUNT_BOUND) -> [User]{
     let users = generateUsers(userBound: 1)
-    generatePostData(bound: postsBound, users: users)
     
    return users
 }
@@ -47,13 +46,10 @@ func generateUsers(userBound: Int = COUNT_BOUND, bound: Int = COUNT_BOUND) -> [U
     
     for _ in 1...numUsers {
         let username = randomString(length: 5)
-        let firstname = randomString(length: 5)
-        let lastname = randomString(length: 5)
         let biography = TEXT_FIXTURES.randomElement()!
-        let age = Int.random(in: 1...bound)
         let karma = Int.random(in: 1...bound)
         let views = Int.random(in: 1...bound)
-        ret.append(User(username: username, firstName: firstname, lastName: lastname, biography: biography, age: age, karma: karma, views: views))
+        ret.append(User(username: username, biography: biography, dateJoined: Date(), karma: karma, views: views))
     }
     return ret
 }

--- a/crumbs/crumbs/ProfileViewController.swift
+++ b/crumbs/crumbs/ProfileViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 extension UIImageView {
 
@@ -18,7 +19,7 @@ extension UIImageView {
 
 class ProfileViewController: UIViewController {
     
-    var user = generateUsersWithPosts(userBound: 1)[0]
+    var user:User = User(firebaseUser: Auth.auth().currentUser!)
     
     private final let POST_CARD_EMBED_SEGUE = "ProfileToCardSegue"
     private final let ABOUT_EMBED_SEGUE = "ProfileToAboutSegue"
@@ -35,8 +36,8 @@ class ProfileViewController: UIViewController {
     }
     
     @IBOutlet weak var aboutView: UIView!
-    
     @IBOutlet weak var postsView: UIView!
+    
     @IBAction func segmentSelect(_ sender: Any) {
         postsView.isHidden = true
         aboutView.isHidden = true


### PR DESCRIPTION
## What this PR does

Pulls user data directly from Firestore on the user profile page, thus eliminating the need for fixtures to generate mock data. The user profile page displays the username, bio, and posts among other data.

## Additional comments

The user page UI is not properly constrained and the username overflows the label container. I've made a [ticket](https://cs371l.atlassian.net/browse/CS371L-47?atlOrigin=eyJpIjoiZTgyYWI3ZTUwMGQ5NGYyZGFjYTRkNWU1ODljZTNiOWMiLCJwIjoiaiJ9) for this.

https://user-images.githubusercontent.com/35646058/199324263-0c39c6b3-0269-41a5-a9d2-c34c370b276e.mov