### PR TITLE
[CS371L-56] Add latitude and longitude to posts

### DIFF
--- a/crumbs/crumbs.xcodeproj/project.pbxproj
+++ b/crumbs/crumbs.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6A2E991129108F9A006D06DF /* SignOutListenerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2E991029108F9A006D06DF /* SignOutListenerViewController.swift */; };
 		6A34E9F328FF391D00699A74 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A34E9F228FF391D00699A74 /* SettingsViewController.swift */; };
 		6A9DA6EF28F9280800B36BE6 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9DA6EE28F9280800B36BE6 /* SignUpViewController.swift */; };
+		6AB1F094291B2EBD00F94C5C /* DeviceLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB1F093291B2EBD00F94C5C /* DeviceLocationService.swift */; };
 		6AFAD74928FFADDD0048EB2F /* IQTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFAD72E28FFADDD0048EB2F /* IQTextView.swift */; };
 		6AFAD74A28FFADDD0048EB2F /* IQKeyboardManager+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFAD72F28FFADDD0048EB2F /* IQKeyboardManager+Internal.swift */; };
 		6AFAD74B28FFADDD0048EB2F /* IQPreviousNextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFAD73128FFADDD0048EB2F /* IQPreviousNextView.swift */; };
@@ -77,6 +78,7 @@
 		6A2E991029108F9A006D06DF /* SignOutListenerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutListenerViewController.swift; sourceTree = "<group>"; };
 		6A34E9F228FF391D00699A74 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		6A9DA6EE28F9280800B36BE6 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		6AB1F093291B2EBD00F94C5C /* DeviceLocationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceLocationService.swift; sourceTree = "<group>"; };
 		6AFAD72E28FFADDD0048EB2F /* IQTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQTextView.swift; sourceTree = "<group>"; };
 		6AFAD72F28FFADDD0048EB2F /* IQKeyboardManager+Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IQKeyboardManager+Internal.swift"; sourceTree = "<group>"; };
 		6AFAD73128FFADDD0048EB2F /* IQPreviousNextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IQPreviousNextView.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 		6A292D4C28F385670068C727 /* crumbs */ = {
 			isa = PBXGroup;
 			children = (
+				6AB1F093291B2EBD00F94C5C /* DeviceLocationService.swift */,
 				88A231832919C37F00755476 /* ErrorMessage.swift */,
 				6AFAD76028FFADE60048EB2F /* PostCreationViewController.swift */,
 				6AFAD72C28FFADDD0048EB2F /* IQKeyboardManagerSwift */,
@@ -362,6 +365,7 @@
 				6AFAD74F28FFADDD0048EB2F /* IQUIView+IQKeyboardToolbar.swift in Sources */,
 				6AFAD75128FFADDD0048EB2F /* IQKeyboardManager+UIKeyboardNotification.swift in Sources */,
 				88B52FE428F92A6C00A0BE08 /* LoginViewController.swift in Sources */,
+				6AB1F094291B2EBD00F94C5C /* DeviceLocationService.swift in Sources */,
 				9C3EACDB2919E44A000DA859 /* EditProfileViewController.swift in Sources */,
 				6AFAD75F28FFADDD0048EB2F /* IQKeyboardManager+UITextFieldViewNotification.swift in Sources */,
 				6A2E991129108F9A006D06DF /* SignOutListenerViewController.swift in Sources */,
@@ -526,6 +530,8 @@
 				DEVELOPMENT_TEAM = SXDY372T6M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = crumbs/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow access to location for best app experience";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please allow access to upload photo to post.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -554,6 +560,8 @@
 				DEVELOPMENT_TEAM = SXDY372T6M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = crumbs/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow access to location for best app experience";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please allow access to upload photo to post.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/crumbs/crumbs.xcodeproj/project.pbxproj
+++ b/crumbs/crumbs.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = crumbs/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow access to location for best app experience";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Please allow access to location for best app experience";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please allow access to upload photo to post.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -561,6 +562,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = crumbs/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Please allow access to location for best app experience";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Please allow access to location for best app experience";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please allow access to upload photo to post.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/crumbs/crumbs/AppDelegate.swift
+++ b/crumbs/crumbs/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreLocation
 import FirebaseCore
 
 extension Date {
@@ -42,13 +43,16 @@ extension Date {
 }
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate {
+    
+    let deviceLocationService = DeviceLocationService.shared
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
         // Framework for scrolling keyboard
         IQKeyboardManager.shared.enable = true
         // Override point for customization after application launch.
+        deviceLocationService.requestLocationUpdates()
         return true
     }
 

--- a/crumbs/crumbs/DeviceLocationService.swift
+++ b/crumbs/crumbs/DeviceLocationService.swift
@@ -50,8 +50,4 @@ class DeviceLocationService: NSObject, CLLocationManagerDelegate {
             manager.stopUpdatingLocation()
         }
     }
-
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        print(locations)
-    }
 }

--- a/crumbs/crumbs/DeviceLocationService.swift
+++ b/crumbs/crumbs/DeviceLocationService.swift
@@ -1,0 +1,53 @@
+//
+//  DeviceLocationService.swift
+//  crumbs
+//
+//  Created by Tristan Blake on 11/8/22.
+//
+
+import Foundation
+import CoreLocation
+
+class DeviceLocationService: NSObject, CLLocationManagerDelegate {
+
+    private override init() {
+        super.init()
+    }
+    static let shared = DeviceLocationService()
+
+    private lazy var locationManager: CLLocationManager = {
+        let manager = CLLocationManager()
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        manager.delegate = self
+        return manager
+    }()
+
+    func requestLocationUpdates() {
+        switch locationManager.authorizationStatus {
+            
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+            
+        case .authorizedWhenInUse, .authorizedAlways:
+            locationManager.startUpdatingLocation()
+            
+        default:
+            break
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+            
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.startUpdatingLocation()
+            
+        default:
+            manager.stopUpdatingLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        print(locations)
+    }
+}

--- a/crumbs/crumbs/DeviceLocationService.swift
+++ b/crumbs/crumbs/DeviceLocationService.swift
@@ -35,6 +35,10 @@ class DeviceLocationService: NSObject, CLLocationManagerDelegate {
             break
         }
     }
+    
+    func getLocation() -> CLLocation? {
+        return self.locationManager.location
+    }
 
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         switch manager.authorizationStatus {

--- a/crumbs/crumbs/Info.plist
+++ b/crumbs/crumbs/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Please allow access to upload photo to post.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/crumbs/crumbs/Post.swift
+++ b/crumbs/crumbs/Post.swift
@@ -27,6 +27,8 @@ class Post {
     var docRef: DocumentReference?
     var imageUrl: String?
     var uiImage: UIImage? = nil
+    var latitude: Float64
+    var longitude: Float64
     
     var user: User? = nil
     
@@ -38,6 +40,8 @@ class Post {
         date: Date,
         likeCount: Int,
         viewCount: Int,
+        latitude: Float64,
+        longitude: Float64,
         comments: [Comment] = [],
         imageUrl: String? = nil
     ) {
@@ -50,6 +54,8 @@ class Post {
         self.viewCount = viewCount
         self.comments = comments
         self.imageUrl = imageUrl
+        self.latitude = latitude
+        self.longitude = longitude
     }
     
     convenience init(snapshot: QueryDocumentSnapshot) {
@@ -63,6 +69,8 @@ class Post {
             date: timestamp.dateValue(),
             likeCount: snapshot.get("likes") as! Int,
             viewCount: snapshot.get("views") as! Int,
+            latitude: snapshot.get("latitude") as! Float64,
+            longitude: snapshot.get("longitude") as! Float64,
             imageUrl: snapshot.get("image_url") as! String?
         )
         self.docRef = snapshot.reference
@@ -76,6 +84,8 @@ class Post {
             "content": self.description,
             "likes": self.likeCount,
             "views": self.viewCount,
+            "latitude": self.latitude,
+            "longitude": self.longitude,
             "comments": self.comments,
             "timestamp": Timestamp(date: self.date),
             "user": userRef,

--- a/crumbs/crumbs/PostCreationViewController.swift
+++ b/crumbs/crumbs/PostCreationViewController.swift
@@ -11,6 +11,7 @@ import FirebaseFirestore
 import FirebaseStorage
 
 import CoreImage.CIFilterBuiltins
+import CoreLocation
 
 class PostCreationViewController: UIViewController, UITextViewDelegate, UITextFieldDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 
@@ -134,6 +135,7 @@ class PostCreationViewController: UIViewController, UITextViewDelegate, UITextFi
          @objc func postPressed() {
              let titleTextStored = titleText.text!
              let descriptionTextStored = descriptionText.text!
+             let location = deviceLocationService.getLocation()
 
              let post = Post(
                 creatorRef: CUR_USER.docRef,
@@ -142,7 +144,9 @@ class PostCreationViewController: UIViewController, UITextViewDelegate, UITextFi
                 title: titleTextStored,
                 date: Date(),
                 likeCount: 0,
-                viewCount: 0
+                viewCount: 0,
+                latitude: location!.coordinate.latitude,
+                longitude: location!.coordinate.longitude
              )
              
              // For now store in an images folder with universally unique

--- a/crumbs/crumbs/PostCreationViewController.swift
+++ b/crumbs/crumbs/PostCreationViewController.swift
@@ -23,6 +23,7 @@ class PostCreationViewController: UIViewController, UITextViewDelegate, UITextFi
     var tableManager: TableManager!
     
     private let storage = Storage.storage().reference()
+    private let deviceLocationService = DeviceLocationService.shared
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## What this PR does

Adds location data to posts. Users will be prompted to give the app permission to use their location. Once granted, posts created by the user will have the user's location data in Firestore.

## Additional comments

There are no UI changes to this PR, so no recording is attached.

### Next steps
- Fetch posts within the user's region
- Restrict posts which are not in the users region/radius